### PR TITLE
fix follow lookup

### DIFF
--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -101,7 +101,7 @@ export class CtznAPI {
       return (await this.view('ctzn.network/followers-view', userId))?.followers
     }
     let [mine, theirs] = await Promise.all([
-      session.isActive() ? this.view('ctzn.network/followers-view', userId) : undefined,
+      session.isActive(domain) ? this.view('ctzn.network/followers-view', userId) : undefined,
       httpGet(domain, `/.view/ctzn.network/followers-view/${encodeURIComponent(userId)}`).catch(e => undefined)
     ])
     if (!mine && !theirs) throw new Error('Failed to fetch any follower information')


### PR DESCRIPTION
profile page for user on anther server did not show a user's follows

line 104 checked if you're connected with your homeserver before trying to query the api, but it _needs_ to check for a connection to the server hosting the _profile you're looking at_.