### PR TITLE
Make toast full width on thiner devices

### DIFF
--- a/static/css/com/toast.css.js
+++ b/static/css/com/toast.css.js
@@ -19,7 +19,7 @@ const cssStr = css`
 }
 .toast {
   position: relative;
-  min-width: var(--toast-min-width);
+  min-width: min(calc(100% - 40px), var(--toast-min-width));
   max-width: 450px;
   background: #ddd;
   margin: 0;


### PR DESCRIPTION
On my phone toasts will align to top right, but will almost always overflow off the left of the screen. This affects even small modals.

This PR changes the styles of toasts, so that at smaller viewport widths toasts will fit to the size of the screen with a slight border around them