### PR TITLE
sort community members list by join date

### DIFF
--- a/static/js/views/user.js
+++ b/static/js/views/user.js
@@ -1217,6 +1217,12 @@ async function listAllMembers (userId) {
     if (m.length < 100) break
     gt = m[m.length - 1].key
   }
+  members = members.sort((a, b) => {
+    let ad = a?.value?.joinDate
+    let bd = b?.value?.joinDate
+    return ad > bd ? 1 : ad < bd ? -1 : 0
+  })
+ 
   return members
 }
 


### PR DESCRIPTION
the non-ordering in the communities ui has been bugging me for ages, so i finally fixed it on my personal viewer.