### PR TITLE
Add apple-touch-icon

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="/css/fontawesome.css">
     <link rel="stylesheet" href="/css/tailwind.css">
     <link rel="icon" href="/img/favicon.png">
+    <link rel="apple-touch-icon" href="/img/icon-192.png">
     <link rel="manifest" href="/manifest.json">
   </head>
   <body class="bg-gray-100">


### PR DESCRIPTION
Implement the unfortunately platform-specific `apple-touch-icon` so the installed PWA doesn't look so dodgy on iOS.

Below: left is before, right is after

![image](https://user-images.githubusercontent.com/18466497/113812581-b1078e00-97b1-11eb-964c-11d6df6584bf.jpeg)