### PR TITLE
add meta tags for ios PWA

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -8,8 +8,12 @@
     <link rel="stylesheet" href="/css/fontawesome.css">
     <link rel="stylesheet" href="/css/tailwind.css">
     <link rel="icon" href="/img/favicon.png">
-    <link rel="apple-touch-icon" href="/img/icon-192.png">
     <link rel="manifest" href="/manifest.json">
+
+    <link rel="apple-touch-icon" href="/img/icon-32.png" sizes="32x32">
+    <link rel="apple-touch-icon" href="/img/icon-144.png" sizes="144x144">
+    <link rel="apple-touch-icon" href="/img/icon-192.png" sizes="192x192">
+    <link rel="apple-touch-icon" href="/img/icon-512.png" sizes="512x512">
   </head>
   <body class="bg-gray-200">
     <app-root></app-root>


### PR DESCRIPTION
The icon doesn't seem to be displaying on my iOS PWA, I think the missing `sizes` property may be to blame.

This needs to be installed from an `https` origin, so I'll test it using the vercel deployment