### PR TITLE
fix profile follow/unfollow switch

### DIFF
--- a/static/js/views/user.js
+++ b/static/js/views/user.js
@@ -109,7 +109,7 @@ class CtznUser extends LitElement {
   }
 
   get amIFollowing () {
-    return !!this.followers?.find?.(id => id === session.info?.userId)
+    return !!session.myFollowing?.find?.(id => id === this.userId)
   }
 
   get isFollowingMe () {


### PR DESCRIPTION
ctznry was checking the profile's self-reported followers instead of the user's following, this does not always work in cross-server environment.